### PR TITLE
Fix the tabindex value set on suggested items.

### DIFF
--- a/src/tagger.js
+++ b/src/tagger.js
@@ -612,7 +612,7 @@
             continue;
           }
           // Create and add the suggestion to the suggestion list
-          var suggestion = $('<li></li>').attr("tabindex", "0").appendTo(this.taggerSuggestionsList);
+          var suggestion = $('<li></li>').attr("tabindex", this.tabIndex).appendTo(this.taggerSuggestionsList);
           if (tag.suggestion && tag.suggestion !== null && tag.suggestion !== '') {
             suggestion.html($('<div/>').html(tag.suggestion).text());
           }


### PR DESCRIPTION
This fixes a bug where the tabindex was always set to zero, even if the
tabindex of the rest of the elements was set to a specific value. This
can cause the focus to skip the suggested items and move to a subsequent
element.
