### PR TITLE
Allow tagger to display in-line with images, etc.

### DIFF
--- a/src/tagger.css
+++ b/src/tagger.css
@@ -6,6 +6,7 @@
   font-size: 10pt;
   padding: 1px 1px 0 1px;
   min-height: 19px;
+  display: inline-block;
 }
 .tagger-readonly {
   background-color: #ebebeb;


### PR DESCRIPTION
Select elements are defaulted to display: inline, the tagger should
follow this behaviour by being styled as an inline block.

Fixes #15.
