### PR TITLE
Improve behaviour when clicking on tagger.

### DIFF
--- a/src/tagger.js
+++ b/src/tagger.js
@@ -246,10 +246,16 @@
               if (!self.singleValue || self.tagCount === 0) {
                 self.taggerWidget.find("input[tabindex]:visible").first().focus();
               }
-              // In single select mode, with a single tag selected already
-              // we should focus the first item in the suggstion list (which
-              // will be the filter input)
-              self._showSuggestions(self.singleValue && self.tagCount === 1);
+              // For now, only show the list automatically on click if we have a single value selected
+              // When performance of the suggestion list building is improved, we can enable this functionality
+              // for multi selectors and empty taggers - note redundant boolean logic preserved so that the following
+              // suggestion parameter is still valid if this check is removed
+              if (self.singleValue && self.tagCount === 1) {
+                // In single select mode, with a single tag selected already
+                // we should focus the first item in the suggstion list (which
+                // will be the filter input)
+                self._showSuggestions(self.singleValue && self.tagCount === 1);
+              }
             }
           });
 
@@ -321,10 +327,17 @@
               }
             }, 
             mouseup: function (event) {
-              // In single select mode, with a single tag selected already
-              // we should focus the first item in the suggstion list (which
-              // will be the filter input)
-              self._showSuggestions(self.singleValue && self.tagCount === 1);
+            
+              // For now, only show the list automatically on click if we have a single value selected
+              // When performance of the suggestion list building is improved, we can enable this functionality
+              // for multi selectors and empty taggers - note redundant boolean logic preserved so that the following
+              // suggestion parameter is still valid if this check is removed
+              if (self.singleValue && self.tagCount === 1) {
+                // In single select mode, with a single tag selected already
+                // we should focus the first item in the suggstion list (which
+                // will be the filter input)
+                self._showSuggestions(self.singleValue && self.tagCount === 1);
+              }
             }
           });
           


### PR DESCRIPTION
Clicking on any area of whitespace within the tagger, including the
input field, will now trigger the suggestion list in both single and
multi select mode. In single-select mode, clicking on the selected tag
will also trigger the suggestion list.

When clearing the selected tag in single-select mode via the (x), the
suggestions list remain open if it is currently open, and the filter
value (if there is one) will be moved to the main input so that
filtering can continue seamlessly.

Solves #10.
