### PR TITLE
Detect clicks outside the tagger using mousedown.

### DIFF
--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -245,7 +245,10 @@
           this.taggerSuggestionsList = $('<ul></ul>').appendTo(this.taggerSuggestions);
 
           // Event listener to hide suggestions list if clicking outside this tagger widget
-          $(document).mouseup(function (event) {
+          // Using mousedown because IE11 reports the event.target for a mouseup as the HTML
+          // root element rather than the original click target, mousedown seems to work 
+          // cross browser
+          $(document).mousedown(function (event) {
             var selfTaggerWidget = self.taggerWidget.get(0);
             if ($(event.target).parents(".tagger").get(0) !== selfTaggerWidget && event.target !== selfTaggerWidget) {
               self.taggerSuggestions.hide();


### PR DESCRIPTION
The mouseup event does not provide the correct click target in IE11
so swap the listener to use the mousedown event instead. This fixes
a bug where the tagger suggestion list could be hidden on IE11 if
clicking on the scrollbar or scroll buttons.

Tested with IE7, IE8, IE9, IE10, IE11, Firefox and Chrome.