### PR TITLE
Fix focus regression in mousedown focus handler.

### DIFF
--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -266,8 +266,13 @@
               if (self.singleValue && self.tagCount === 1) {
                 // In single select mode, with a single tag selected already
                 // we should focus the first item in the suggstion list (which
-                // will be the filter input)
-                self._showSuggestions(self.singleValue && self.tagCount === 1);
+                // will be the filter input).
+                // NB: Using setTimeout because trying to do this immediately causes
+                // the focus to fail, presumably because the corresponding mouseup triggers
+                // focus elsewhere.
+                setTimeout(function(){
+                  self._showSuggestions(self.singleValue && self.tagCount === 1);
+                }, 0);
               }
             }
           });


### PR DESCRIPTION
The switch from mouseup to mousedown breaks the automatic focus
feature in single select mode, when mandatorySelection is false,
presumably because the subsequent mouseup event takes focus. The
simple fix here is to show the suggestion list and focus
asynchronously.