### PR TITLE
Further accessibility enhancements

### DIFF
--- a/src/jquery.tagger.css
+++ b/src/jquery.tagger.css
@@ -203,3 +203,16 @@
 .tagger .suggestions ul li.addfreetext.focus {
   background-color: #c9f9c6;
 }
+
+.tagger .tagger-audible-status {
+  border: 0px;
+  clip: rect(0px, 0px, 0px, 0px);
+  height: 1px;
+  margin-bottom: -1px;
+  margin-right: -1px;
+  overflow: hidden;
+  padding: 0px;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;  
+}

--- a/src/jquery.tagger.css
+++ b/src/jquery.tagger.css
@@ -9,7 +9,7 @@
   display: inline-block;
 }
 .tagger.focus {
-  outline: auto 5px #69CAE8;
+  outline: 2px solid #69CAE8;
 }
 .tagger-readonly {
   background-color: #ebebeb;

--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -281,8 +281,6 @@
             this.taggerSuggestionsButton = $('<div>')
               .addClass('droparrow')
               .addClass('hittarget')
-              .attr('aria-label', 'Toggle option display')
-              .attr('role', 'button')
               .bind('mouseup keyup', $.proxy(this._handleSuggestionsButtonInteraction, this))
               .appendTo(this.taggerButtonsPanel);
             $('<img>')
@@ -303,8 +301,6 @@
               .appendTo(this.taggerSuggestionsButton);
           }
 
-          this.taggerSuggestionsButton.attr("tabindex", this.tabIndex);
-
           // Add placeholder text to text input field
           if (this.options.placeholder !== null) {
             this.taggerInput.attr("placeholder", this.options.placeholder);
@@ -324,6 +320,13 @@
 
               // Select the widget itself again
               this._getWidgetFocusable().focus();
+            }
+
+            if (event.target && event.altKey && (event.which === this.keyCodes.DOWN || event.which === this.keyCodes.UP)) {
+              this._toggleShowSuggestions();
+
+              // Select the widget itself again
+              this._getWidgetFocusable().focus();              
             }
           }, this));
 
@@ -574,7 +577,7 @@
             }
           }
           else if (event.which === this.keyCodes.DOWN) { // Down Arrow
-            if (isMainInput) {
+            if (isMainInput && !event.altKey) {
               if (!this.options.ajaxURL || this.taggerSuggestions.is(":visible")) {
                 this._showSuggestions(true);
               }
@@ -613,17 +616,26 @@
           this.taggerWidget.find("input[tabindex]:visible").first().focus();
         }
         else {
-          // If the suggestion list is visible already, then toggle it off
-          if (this.taggerSuggestions.is(":visible")) {
-            this._hideSuggestions();
-          }
-          // otherwise show it
-          else {
-            this._showSuggestions(true);
-          }
+          this._toggleShowSuggestions();
         }
         event.preventDefault();
       }
+    },
+
+    /**
+     * Toggle whether suggestions are shown or not
+     *
+     * @private
+     */
+    _toggleShowSuggestions: function() {
+      // If the suggestion list is visible already, then toggle it off
+      if (this.taggerSuggestions.is(":visible")) {
+        this._hideSuggestions();
+      }
+      // otherwise show it
+      else {
+        this._showSuggestions(true);
+      }      
     },
 
     /**

--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -320,8 +320,8 @@
           // Set the tab index on the input field
           this.taggerInput.attr("tabindex", this.tabIndex);
 
-          // Esc should hide the tagger suggestions globally
           this.taggerWidget.bind('keydown', $.proxy(function (event) {
+            // Esc should hide the tagger suggestions globally
             if (event.target && event.which === this.keyCodes.ESC) { // Esc
               this._hideSuggestions();
 
@@ -329,11 +329,17 @@
               this._getWidgetFocusable().focus();
             }
 
+            // Alt+down and alt+up should toggle the suggestions list
             if (event.target && event.altKey && (event.which === this.keyCodes.DOWN || event.which === this.keyCodes.UP)) {
               this._toggleShowSuggestions();
 
               // Select the widget itself again
               this._getWidgetFocusable().focus();              
+            }
+
+            // Down arrow shows suggestions list if not visible
+            if (event.target && !this.options.ajaxURL && !this.taggerSuggestions.is(":visible") && event.which === this.keyCodes.DOWN) {
+              this._showSuggestions(true);           
             }
           }, this));
 

--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -264,13 +264,21 @@
           .appendTo(this.taggerWidget);
 
         if (!this.readonly) {
+
+          var ariaLabel = "Autocomplete filter";
+          if(this.taggerWidget.attr('aria-label')) {
+            ariaLabel += ' for ' + this.taggerWidget.attr('aria-label');
+          } else if(this.taggerWidget.attr('aria-labelledby')) {
+            ariaLabel += ' for ' + $('#'+this.taggerWidget.attr('aria-labelledby')).text();
+          }
+
           // Add the suggestion drop arrow and and text input if not readonly
           this.taggerInput = $('<input>')
             .attr('type', 'text')
             .attr('autocomplete', 'off')
             .addClass('intxt')
             .attr('role', 'textbox')
-            .attr('aria-label', 'Autocomplete input box')
+            .attr('aria-label', ariaLabel)
             .attr('aria-controls', this.suggestionsListID)
             .appendTo(this.taggerWidget);
           this.taggerButtonsPanel = $('<div>').addClass('tagger-buttons');

--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -234,8 +234,7 @@
 
         if (this.element.attr('aria-label')) {
           this.taggerWidget.attr('aria-label', this.element.attr('aria-label'));
-        }
-        if ($('label[for=' + this.element.prop('id') + ']')) {
+        } else if ($('label[for=' + this.element.prop('id') + ']')) {
           this.taggerWidget.attr('aria-labelledby', $('label[for=' + this.element.prop('id') + ']').first().prop('id'));
         }
 

--- a/src/jquery.tagger.js
+++ b/src/jquery.tagger.js
@@ -1164,13 +1164,15 @@
         // Handle suggestion adding
         var suggestionItem = $(event.target).closest('li');
         if (suggestionItem.data('tagid') && !suggestionItem.data('freetext')) {
-          this._addTagFromID(suggestionItem.data('tagid'));
-          this._setAudibleStatus("Selected " + this.tagsByID[suggestionItem.data('tagid')].key);
+          var tagId = suggestionItem.data('tagid')
+          this._addTagFromID(tagId);
+          this._setAudibleStatus("Selected " + this.tagsByID[tagId].key);
           this._selectionReset(true, true);
         }
         else if (suggestionItem.data('freetext') && !suggestionItem.data('tagid')) {
-          this._addFreeText(suggestionItem.data('freetext'));
-          this._setAudibleStatus("Added " + this.tagsByID[suggestionItem.data('tagid')].key);
+          var freetext = suggestionItem.data('freetext');
+          this._addFreeText(freetext);
+          this._setAudibleStatus("Added " + freetext);
           this._selectionReset(true, true);
         }
         else {


### PR DESCRIPTION
Further accessibility improvements to the tagger widget, notably

1. Adding ariaDescribedBy parameter
2. Added tag guidance to tell screen reader users how to remove a tag
3. Added audio guidance to outline the current selection when the widget is first focused
4. Made selected tags a list to make relationship clear to screen readers
5. Expose hierarchical levels directly to screen readers

And some basic code clean up that IntelliJ moaned about